### PR TITLE
Add sections and collapsible UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project is a simple customizable launcher written in Python using
 ## Features
 
 - **Grid interface** with icons and names for each item.
+- **Organize items into sections** displayed as collapsible lists.
 - **Configurable** via external YAML file (`config.yaml`).
 - Launch applications, scripts and open URLs.
 - Edit items directly from the application or by modifying `config.yaml`.
@@ -28,31 +29,37 @@ python -m launcher.main
 ```
 
 The launcher reads `config.yaml` located in the project root. Modify this
-file to change buttons, icons and commands.
+file to change sections, buttons, icons and commands.
 
 ### Editing within the app
 
-Use the **Config** menu in the application window to add, edit or remove
-entries. Changes are saved back to `config.yaml` and the UI can be reloaded
+Use the **Config** menu in the application window to manage sections and
+items. Changes are saved back to `config.yaml` and the UI can be reloaded
 using the same menu.
 
 ## Configuration file format
 
 ```yaml
-items:
-  - name: Firefox
-    type: application
-    command: firefox
-    icon: /usr/share/icons/hicolor/48x48/apps/firefox.png
-  - name: Terminal
-    type: application
-    command: gnome-terminal
-  - name: Update Script
-    type: script
-    command: /home/user/update.sh
-  - name: Open GitHub
-    type: url
-    command: https://github.com
+sections:
+  - name: Applications
+    items:
+      - name: Firefox
+        type: application
+        command: firefox
+        icon: /usr/share/icons/hicolor/48x48/apps/firefox.png
+      - name: Terminal
+        type: application
+        command: gnome-terminal
+  - name: Scripts
+    items:
+      - name: Update Script
+        type: script
+        command: /home/user/update.sh
+  - name: Websites
+    items:
+      - name: Open GitHub
+        type: url
+        command: https://github.com
 ```
 
 Each item has:
@@ -61,6 +68,11 @@ Each item has:
 - `type`: one of `application`, `script` or `url`.
 - `command`: command to run or URL to open.
 - `icon` (optional): path to an icon image.
+
+Each section has:
+
+- `name`: section title displayed in the launcher.
+- `items`: list of items within the section.
 
 ## Extending
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,14 +1,20 @@
-items:
-  - name: Firefox
-    type: application
-    command: firefox
-    icon: /usr/share/icons/hicolor/48x48/apps/firefox.png
-  - name: Terminal
-    type: application
-    command: gnome-terminal
-  - name: Update Script
-    type: script
-    command: /home/user/update.sh
-  - name: Open GitHub
-    type: url
-    command: https://github.com
+sections:
+  - name: Applications
+    items:
+      - name: Firefox
+        type: application
+        command: firefox
+        icon: /usr/share/icons/hicolor/48x48/apps/firefox.png
+      - name: Terminal
+        type: application
+        command: gnome-terminal
+  - name: Scripts
+    items:
+      - name: Update Script
+        type: script
+        command: /home/user/update.sh
+  - name: Websites
+    items:
+      - name: Open GitHub
+        type: url
+        command: https://github.com

--- a/launcher/config.py
+++ b/launcher/config.py
@@ -14,10 +14,15 @@ def load_config(path: Path = CONFIG_PATH) -> List[Dict[str, Any]]:
         return []
     with path.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
-    return data.get("items", [])
+    if "sections" in data:
+        return data["sections"]
+    if "items" in data:
+        # backwards compatibility with older config format
+        return [{"name": "Default", "items": data.get("items", [])}]
+    return []
 
 
-def save_config(items: List[Dict[str, Any]], path: Path = CONFIG_PATH) -> None:
+def save_config(sections: List[Dict[str, Any]], path: Path = CONFIG_PATH) -> None:
     """Save configuration back to YAML file."""
     with path.open("w", encoding="utf-8") as f:
-        yaml.dump({"items": items}, f, allow_unicode=True)
+        yaml.dump({"sections": sections}, f, allow_unicode=True)

--- a/launcher/dialogs.py
+++ b/launcher/dialogs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Dict, Any
 
 from PySide6 import QtWidgets, QtGui
@@ -64,3 +64,23 @@ class ItemDialog(QtWidgets.QDialog):
             command=self.command_edit.text().strip(),
             icon=self.icon_edit.text().strip() or None,
         )
+
+
+class SectionDialog(QtWidgets.QDialog):
+    """Dialog to create or edit sections."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None, name: str = "") -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Section")
+
+        layout = QtWidgets.QFormLayout(self)
+        self.name_edit = QtWidgets.QLineEdit(name)
+        layout.addRow("Name", self.name_edit)
+
+        button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addRow(button_box)
+
+    def get_name(self) -> str:
+        return self.name_edit.text().strip()

--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -10,18 +10,19 @@ from typing import List, Dict, Any
 from PySide6 import QtWidgets, QtGui, QtCore
 
 from .config import load_config, save_config, CONFIG_PATH
-from .dialogs import ItemDialog, ItemData
+from .dialogs import ItemDialog, ItemData, SectionDialog
 
 
 class LauncherWindow(QtWidgets.QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Launcher")
-        self.items: List[Dict[str, Any]] = []
+        self.sections: List[Dict[str, Any]] = []
         self.central = QtWidgets.QWidget()
         self.setCentralWidget(self.central)
-        self.grid = QtWidgets.QGridLayout(self.central)
-        self.grid.setSpacing(10)
+        self.layout = QtWidgets.QVBoxLayout(self.central)
+        self.tool_box = QtWidgets.QToolBox()
+        self.layout.addWidget(self.tool_box)
 
         self._create_menu()
         self.reload_items()
@@ -29,6 +30,18 @@ class LauncherWindow(QtWidgets.QMainWindow):
     def _create_menu(self) -> None:
         menubar = self.menuBar()
         config_menu = menubar.addMenu("Config")
+
+        add_section = QtGui.QAction("Add Section", self)
+        add_section.triggered.connect(self.add_section)
+        config_menu.addAction(add_section)
+
+        edit_section = QtGui.QAction("Edit Section", self)
+        edit_section.triggered.connect(self.edit_section)
+        config_menu.addAction(edit_section)
+
+        remove_section = QtGui.QAction("Remove Section", self)
+        remove_section.triggered.connect(self.remove_section)
+        config_menu.addAction(remove_section)
 
         add_action = QtGui.QAction("Add Item", self)
         add_action.triggered.connect(self.add_item)
@@ -50,30 +63,62 @@ class LauncherWindow(QtWidgets.QMainWindow):
         reload_action.triggered.connect(self.reload_items)
         config_menu.addAction(reload_action)
 
+    def add_section(self) -> None:
+        dlg = SectionDialog(self)
+        if dlg.exec() == QtWidgets.QDialog.Accepted:
+            self.sections.append({"name": dlg.get_name(), "items": []})
+            save_config(self.sections)
+            self.reload_items()
+
+    def edit_section(self) -> None:
+        if not self.sections:
+            return
+        idx = self._select_section("Edit Section", "Select section")
+        if idx is None:
+            return
+        dlg = SectionDialog(self, self.sections[idx].get("name", ""))
+        if dlg.exec() == QtWidgets.QDialog.Accepted:
+            self.sections[idx]["name"] = dlg.get_name()
+            save_config(self.sections)
+            self.reload_items()
+
+    def remove_section(self) -> None:
+        if not self.sections:
+            return
+        idx = self._select_section("Remove Section", "Select section")
+        if idx is not None:
+            del self.sections[idx]
+            save_config(self.sections)
+            self.reload_items()
+
     def reload_items(self) -> None:
         """Reload items from configuration and rebuild UI."""
-        self.items = load_config()
-        for i in reversed(range(self.grid.count())):
-            widget = self.grid.itemAt(i).widget()
-            if widget:
-                widget.setParent(None)
+        self.sections = load_config()
+        self.tool_box.clear()
 
-        columns = 4
-        row = col = 0
-        for item in self.items:
-            button = QtWidgets.QToolButton()
-            button.setText(item.get("name", ""))
-            button.setToolButtonStyle(QtCore.Qt.ToolButtonTextUnderIcon)
-            icon_path = item.get("icon")
-            if icon_path and Path(icon_path).exists():
-                button.setIcon(QtGui.QIcon(icon_path))
-            button.setIconSize(QtCore.QSize(64, 64))
-            button.clicked.connect(lambda _, it=item: self.launch_item(it))
-            self.grid.addWidget(button, row, col)
-            col += 1
-            if col >= columns:
-                col = 0
-                row += 1
+        for section in self.sections:
+            widget = QtWidgets.QWidget()
+            grid = QtWidgets.QGridLayout(widget)
+            grid.setSpacing(10)
+
+            columns = 4
+            row = col = 0
+            for item in section.get("items", []):
+                button = QtWidgets.QToolButton()
+                button.setText(item.get("name", ""))
+                button.setToolButtonStyle(QtCore.Qt.ToolButtonTextUnderIcon)
+                icon_path = item.get("icon")
+                if icon_path and Path(icon_path).exists():
+                    button.setIcon(QtGui.QIcon(icon_path))
+                button.setIconSize(QtCore.QSize(64, 64))
+                button.clicked.connect(lambda _, it=item: self.launch_item(it))
+                grid.addWidget(button, row, col)
+                col += 1
+                if col >= columns:
+                    col = 0
+                    row += 1
+
+            self.tool_box.addItem(widget, section.get("name", ""))
 
     # --- actions ---
     def launch_item(self, item: Dict[str, Any]) -> None:
@@ -88,33 +133,52 @@ class LauncherWindow(QtWidgets.QMainWindow):
             subprocess.Popen(cmd, shell=True)
 
     def add_item(self) -> None:
+        if not self.sections:
+            QtWidgets.QMessageBox.warning(self, "No Sections", "Please add a section first.")
+            return
+        idx = self._select_section("Add Item", "Select section")
+        if idx is None:
+            return
         dlg = ItemDialog(self)
         if dlg.exec() == QtWidgets.QDialog.Accepted:
-            self.items.append(dlg.get_data().__dict__)
-            save_config(self.items)
+            self.sections[idx].setdefault("items", []).append(dlg.get_data().__dict__)
+            save_config(self.sections)
             self.reload_items()
 
     def edit_item(self) -> None:
-        if not self.items:
+        if not self.sections:
             return
-        names = [it.get("name", "") for it in self.items]
+        sec_idx = self._select_section("Edit Item", "Select section")
+        if sec_idx is None or not self.sections[sec_idx].get("items"):
+            return
+        names = [it.get("name", "") for it in self.sections[sec_idx]["items"]]
         item, ok = QtWidgets.QInputDialog.getItem(self, "Edit Item", "Select item", names, 0, False)
         if ok and item:
             idx = names.index(item)
-            current = ItemData(**self.items[idx])
+            current = ItemData(**self.sections[sec_idx]["items"][idx])
             dlg = ItemDialog(self, current)
             if dlg.exec() == QtWidgets.QDialog.Accepted:
-                self.items[idx] = dlg.get_data().__dict__
-                save_config(self.items)
+                self.sections[sec_idx]["items"][idx] = dlg.get_data().__dict__
+                save_config(self.sections)
                 self.reload_items()
 
     def remove_item(self) -> None:
-        if not self.items:
+        if not self.sections:
             return
-        names = [it.get("name", "") for it in self.items]
+        sec_idx = self._select_section("Remove Item", "Select section")
+        if sec_idx is None or not self.sections[sec_idx].get("items"):
+            return
+        names = [it.get("name", "") for it in self.sections[sec_idx]["items"]]
         item, ok = QtWidgets.QInputDialog.getItem(self, "Remove Item", "Select item", names, 0, False)
         if ok and item:
             idx = names.index(item)
-            del self.items[idx]
-            save_config(self.items)
+            del self.sections[sec_idx]["items"][idx]
+            save_config(self.sections)
             self.reload_items()
+
+    def _select_section(self, title: str, label: str) -> int | None:
+        names = [sec.get("name", "") for sec in self.sections]
+        section, ok = QtWidgets.QInputDialog.getItem(self, title, label, names, 0, False)
+        if ok and section:
+            return names.index(section)
+        return None


### PR DESCRIPTION
## Summary
- support grouping items into sections in `config.yaml`
- implement collapsible section lists in the GUI with `QToolBox`
- allow adding, editing and removing sections from the menu
- update launcher configuration logic for backward compatibility
- document new features and configuration format

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `python -m launcher.main` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6861a905d3a08329b3944a02e5b215c2