### PR TITLE
Add settings tab with embedded config editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Use the **Configure** options in the tray icon menu to manage sections and
 items. Changes are saved back to `config.yaml` and the UI can be reloaded
 from the same menu.
 
+The launcher also includes a **Settings** tab with a built-in text editor for
+`config.yaml`. Open this tab to quickly tweak your configuration and save the
+file without leaving the application.
+
 ## Configuration file format
 
 ```yaml


### PR DESCRIPTION
## Summary
- embed a simple config editor widget
- add a Settings tab that uses the editor
- document the Settings tab in the README

## Testing
- `python -m py_compile launcher/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6861b31707a48329a56e1a20de43ef3a