### PR TITLE
Improve launcher UI with themes and collapsible panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This project is a simple customizable launcher written in Python using
 [PySide6](https://doc.qt.io/qtforpython/).
 
-## Features
+-## Features
 
-- **Horizontal panel** with icons and names for each item.
-- **Organize items into tabs** for different sections.
+- **Draggable panel** that remembers its position.
+- **Collapsible sections** to save screen space.
+- **Light and dark themes** configurable via `config.yaml` or the menu.
 - **Configurable** via external YAML file (`config.yaml`).
 - Launch applications, scripts and open URLs.
 - Edit items directly from the application or by modifying `config.yaml`.
@@ -44,6 +45,9 @@ from the same menu.
 ## Configuration file format
 
 ```yaml
+theme: dark
+panel:
+  position: top
 sections:
   - name: Applications
     items:

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
+theme: dark
 panel:
   position: top
 sections:

--- a/launcher/config.py
+++ b/launcher/config.py
@@ -1,11 +1,12 @@
 """Configuration loader and saver for the launcher."""
 
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 import yaml
 
 DEFAULT_PANEL_POSITION = "top"
+DEFAULT_THEME = "dark"
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
 
@@ -22,6 +23,39 @@ def load_config(path: Path = CONFIG_PATH) -> List[Dict[str, Any]]:
         # backwards compatibility with older config format
         return [{"name": "Default", "items": data.get("items", [])}]
     return []
+
+
+def load_theme(path: Path = CONFIG_PATH) -> str:
+    """Return theme name stored in config file or the default."""
+    if not path.exists():
+        return DEFAULT_THEME
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return str(data.get("theme", DEFAULT_THEME))
+
+
+def load_panel_geometry(path: Path = CONFIG_PATH) -> Tuple[int, int]:
+    """Return saved panel position for draggable mode."""
+    if not path.exists():
+        return 0, 0
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    panel = data.get("panel", {})
+    return int(panel.get("x", 0)), int(panel.get("y", 0))
+
+
+def save_panel_geometry(x: int, y: int, path: Path = CONFIG_PATH) -> None:
+    """Persist panel coordinates back into config file."""
+    data: Dict[str, Any] = {}
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    panel = data.get("panel", {})
+    panel["x"] = int(x)
+    panel["y"] = int(y)
+    data["panel"] = panel
+    with path.open("w", encoding="utf-8") as f:
+        yaml.dump(data, f, allow_unicode=True)
 
 
 def load_panel_position(path: Path = CONFIG_PATH) -> str:

--- a/launcher/styles/dark.qss
+++ b/launcher/styles/dark.qss
@@ -1,0 +1,28 @@
+QWidget {
+    background-color: #2b2b2b;
+    color: #ffffff;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+}
+QToolBox::tab {
+    background: #3c3c3c;
+    color: #dddddd;
+    padding: 4px 8px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+QToolBox::tab:selected {
+    background: #555555;
+}
+QToolButton {
+    background: #3c3c3c;
+    border: 1px solid #555555;
+    border-radius: 10px;
+    padding: 6px;
+}
+QToolButton:hover {
+    background: #4c4c4c;
+}
+QToolButton:pressed {
+    background: #626262;
+}

--- a/launcher/styles/light.qss
+++ b/launcher/styles/light.qss
@@ -1,0 +1,28 @@
+QWidget {
+    background-color: #f0f0f0;
+    color: #000000;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+}
+QToolBox::tab {
+    background: #e0e0e0;
+    color: #444444;
+    padding: 4px 8px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+QToolBox::tab:selected {
+    background: #c0c0c0;
+}
+QToolButton {
+    background: #e0e0e0;
+    border: 1px solid #c0c0c0;
+    border-radius: 10px;
+    padding: 6px;
+}
+QToolButton:hover {
+    background: #d0d0d0;
+}
+QToolButton:pressed {
+    background: #b0b0b0;
+}


### PR DESCRIPTION
## Summary
- add light and dark themes in external QSS files
- move stylesheet loading to runtime and support theme toggle
- implement draggable launcher window remembering its position
- show items inside collapsible sections instead of tabs
- add fade animation for panel visibility and button presses
- document new configuration format and features

## Testing
- `python -m py_compile launcher/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6861bedf7fa48329a552a629b1e1f9a9