### PR TITLE
Add settings tab and horizontal layout

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -275,12 +275,20 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self._drag_pos: QtCore.QPoint | None = None
 
         self.sections: List[Dict[str, Any]] = []
-        self.central = QtWidgets.QWidget()
-        self.setCentralWidget(self.central)
-        self.layout = QtWidgets.QVBoxLayout(self.central)
+        # Use a tab widget so the main interface and settings are separated
+        self.tabs = QtWidgets.QTabWidget()
+        self.setCentralWidget(self.tabs)
+
+        # --- launcher page ---
+        self.launcher_page = QtWidgets.QWidget()
+        self.layout = QtWidgets.QHBoxLayout(self.launcher_page)
         self.layout.setContentsMargins(8, 4, 8, 4)
         self.section_widgets: List[CollapsibleSection] = []
+        self.tabs.addTab(self.launcher_page, "Launcher")
+
+        # --- settings page ---
         self.config_editor = ConfigManager()
+        self.tabs.addTab(self.config_editor, "Settings")
 
         self._create_menu()
         self.menuBar().hide()
@@ -417,8 +425,6 @@ class LauncherWindow(QtWidgets.QMainWindow):
             self.layout.removeWidget(w)
             w.deleteLater()
         self.section_widgets.clear()
-        if self.config_editor.parent():
-            self.layout.removeWidget(self.config_editor)
 
         for section in self.sections:
             widget = QtWidgets.QWidget()
@@ -444,8 +450,6 @@ class LauncherWindow(QtWidgets.QMainWindow):
             self.layout.addWidget(sec)
             self.section_widgets.append(sec)
 
-        # Add settings area at the bottom
-        self.layout.addWidget(self.config_editor)
         self.config_editor.reload()
         self.adjustSize()
 

--- a/launcher/styles/dark.qss
+++ b/launcher/styles/dark.qss
@@ -18,11 +18,15 @@ QToolButton {
     background: #3c3c3c;
     border: 1px solid #555555;
     border-radius: 10px;
-    padding: 6px;
+    padding: 8px;
 }
 QToolButton:hover {
     background: #4c4c4c;
 }
 QToolButton:pressed {
     background: #626262;
+}
+
+QLineEdit, QComboBox, QPlainTextEdit {
+    padding: 4px;
 }

--- a/launcher/styles/light.qss
+++ b/launcher/styles/light.qss
@@ -18,11 +18,15 @@ QToolButton {
     background: #e0e0e0;
     border: 1px solid #c0c0c0;
     border-radius: 10px;
-    padding: 6px;
+    padding: 8px;
 }
 QToolButton:hover {
     background: #d0d0d0;
 }
 QToolButton:pressed {
     background: #b0b0b0;
+}
+
+QLineEdit, QComboBox, QPlainTextEdit {
+    padding: 4px;
 }


### PR DESCRIPTION
## Summary
- switch main layout to horizontal and introduce tab widget
- add visible **Settings** tab
- tweak QSS styles to improve text spacing

## Testing
- `python -m launcher.main` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6861c2a886d0832989ce7a0623533331