### PR TITLE
Enable dropdown collapse on second click

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -275,15 +275,23 @@ class DropdownSection(QtWidgets.QWidget):
         self.button = QtWidgets.QToolButton(text=title)
         self.button.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
         self.button.setArrowType(QtCore.Qt.DownArrow)
-        self.button.clicked.connect(self._show_menu)
+        self.button.clicked.connect(self._toggle_menu)
+
+        self._menu: QtWidgets.QMenu | None = None
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.button)
 
-    def _show_menu(self) -> None:
+    def _toggle_menu(self) -> None:
+        """Show the dropdown menu or hide it if already visible."""
+        if self._menu and self._menu.isVisible():
+            self._menu.close()
+            return
+
         menu = QtWidgets.QMenu(self)
+        menu.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         for item in self._items:
             action = QtGui.QAction(item.get("name", ""), menu)
             icon_path = item.get("icon")
@@ -291,8 +299,11 @@ class DropdownSection(QtWidgets.QWidget):
                 action.setIcon(QtGui.QIcon(icon_path))
             action.triggered.connect(lambda _, it=item: self._trigger(it))
             menu.addAction(action)
+
         pos = self.button.mapToGlobal(QtCore.QPoint(0, self.button.height()))
-        menu.exec(pos)
+        menu.popup(pos)
+        menu.aboutToHide.connect(lambda: setattr(self, "_menu", None))
+        self._menu = menu
 
 
 class LauncherWindow(QtWidgets.QMainWindow):


### PR DESCRIPTION
## Summary
- toggle dropdown sections instead of always opening menu

## Testing
- `flake8 launcher`
- `python -m launcher.main` *(fails: could not load Qt platform plugin `xcb`)*

------
https://chatgpt.com/codex/tasks/task_e_6861d36ef28c8329ac1a1a60c8dd098b