### PR TITLE
Fix dropdown arrow resetting

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -259,6 +259,7 @@ class DropdownSection(QtWidgets.QWidget):
         if self._menu is not None:
             menu = self._menu
             self._menu = None
+            self.button.setArrowType(QtCore.Qt.DownArrow)
             menu.close()
             return
 


### PR DESCRIPTION
## Summary
- fix menu arrow resetting by resetting the arrow before closing the menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m launcher.main` *(fails: `ModuleNotFoundError: No module named 'PySide6'`)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7e682fc832984a7998ddf33aafb