### PR TITLE
Highlight active section

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -234,6 +234,7 @@ class DropdownSection(QtWidgets.QWidget):
         self.button = QtWidgets.QToolButton(text=title)
         self.button.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
         self.button.setArrowType(QtCore.Qt.DownArrow)
+        self.button.setCheckable(True)
         # Use the pressed signal so that releasing the mouse doesn't immediately
         # trigger another toggle which would reopen the menu.
         self.button.pressed.connect(self._toggle_menu)
@@ -270,6 +271,7 @@ class DropdownSection(QtWidgets.QWidget):
             menu = self._menu
             self._menu = None
             self.button.setArrowType(QtCore.Qt.DownArrow)
+            self.button.setChecked(False)
             menu.close()
             return
 
@@ -290,10 +292,12 @@ class DropdownSection(QtWidgets.QWidget):
         menu.aboutToHide.connect(self._menu_closed)
         self._menu = menu
         self.button.setArrowType(QtCore.Qt.UpArrow)
+        self.button.setChecked(True)
 
     def _menu_closed(self) -> None:
         self._menu = None
         self.button.setArrowType(QtCore.Qt.DownArrow)
+        self.button.setChecked(False)
 
 
 class LauncherWindow(QtWidgets.QMainWindow):

--- a/launcher/styles/dark.qss
+++ b/launcher/styles/dark.qss
@@ -26,6 +26,9 @@ QToolButton:hover {
 QToolButton:pressed {
     background: #626262;
 }
+QToolButton:checked {
+    background: #626262;
+}
 
 QLineEdit, QComboBox, QPlainTextEdit {
     padding: 4px;

--- a/launcher/styles/light.qss
+++ b/launcher/styles/light.qss
@@ -26,6 +26,9 @@ QToolButton:hover {
 QToolButton:pressed {
     background: #b0b0b0;
 }
+QToolButton:checked {
+    background: #b0b0b0;
+}
 
 QLineEdit, QComboBox, QPlainTextEdit {
     padding: 4px;


### PR DESCRIPTION
## Summary
- keep dropdown button checked while its menu is open
- add `QToolButton:checked` styling for dark/light themes

## Testing
- `python -m py_compile launcher/gui.py launcher/config.py launcher/dialogs.py launcher/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6861ee039a28832998c2cab067c962a5