### PR TITLE
Add top-edge snap behavior

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -301,6 +301,11 @@ class DropdownSection(QtWidgets.QWidget):
 
 
 class LauncherWindow(QtWidgets.QMainWindow):
+    """Main window for the launcher."""
+
+    #: Distance in pixels from the top edge before snapping occurs.
+    SNAP_THRESHOLD = 20
+
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Launcher")
@@ -598,5 +603,8 @@ class LauncherWindow(QtWidgets.QMainWindow):
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
         if self._drag_pos is not None:
             self._drag_pos = None
+            # Snap to the top edge if released close enough
+            if self.y() < self.SNAP_THRESHOLD:
+                self.move(self.x(), 0)
             save_panel_geometry(self.x(), self.y())
         super().mouseReleaseEvent(event)


### PR DESCRIPTION
## Summary
- add `SNAP_THRESHOLD` and snap the window to the top when released close to the edge

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m launcher.main` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6861ef904fbc832999397e3f9bfe7de6