### PR TITLE
Add timer to reset section highlight

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -293,6 +293,8 @@ class DropdownSection(QtWidgets.QWidget):
         self._menu = menu
         self.button.setArrowType(QtCore.Qt.UpArrow)
         self.button.setChecked(True)
+        # reset section highlight after 5 seconds
+        QtCore.QTimer.singleShot(5000, lambda: self.button.setChecked(False))
 
     def _menu_closed(self) -> None:
         self._menu = None


### PR DESCRIPTION
## Summary
- highlight active section for 5 seconds only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f142bdf48329830da0533e0c80cb