### PR TITLE
Fix stuck section highlight on fast clicks

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -272,6 +272,7 @@ class DropdownSection(QtWidgets.QWidget):
             self._menu = None
             self.button.setArrowType(QtCore.Qt.DownArrow)
             self.button.setChecked(False)
+            self.button.setDown(False)
             menu.close()
             return
 
@@ -298,6 +299,9 @@ class DropdownSection(QtWidgets.QWidget):
         self._menu = None
         self.button.setArrowType(QtCore.Qt.DownArrow)
         self.button.setChecked(False)
+        # Ensure the pressed state is cleared so the style resets even if the
+        # release event was swallowed by the menu.
+        self.button.setDown(False)
 
 
 class LauncherWindow(QtWidgets.QMainWindow):


### PR DESCRIPTION
## Summary
- clear pressed state when dropdown sections close so the color resets

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861f395bfd883298fc6051a06da7bc1