### PR TITLE
Fix dropdown button state reset

### DIFF
--- a/launcher/gui.py
+++ b/launcher/gui.py
@@ -302,6 +302,9 @@ class DropdownSection(QtWidgets.QWidget):
         # Ensure the pressed state is cleared so the style resets even if the
         # release event was swallowed by the menu.
         self.button.setDown(False)
+        # Reset skip flag in case the closing click was intercepted by the menu
+        # and no button press event followed.
+        self._skip_toggle = False
 
 
 class LauncherWindow(QtWidgets.QMainWindow):


### PR DESCRIPTION
## Summary
- fix stuck highlight by resetting `_skip_toggle`

## Testing
- `python -m py_compile launcher/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6861f4ea92e88329b41e3dcf4bb7c7ae